### PR TITLE
Fix missing translations

### DIFF
--- a/config/locales/layouts.yml
+++ b/config/locales/layouts.yml
@@ -1,0 +1,9 @@
+mn:
+  layouts:
+    application:
+      contests: Contests
+      problems: Problems
+      blogs: Blogs
+      coders: Coders
+      login: Login
+      signup: Register

--- a/config/locales/layouts.yml
+++ b/config/locales/layouts.yml
@@ -10,3 +10,7 @@ mn:
       about: About
       help: Help
       issues: Issues
+      account: Account
+      preferences: Preferences
+      dashboard: Dashboard
+      logout: Logout

--- a/config/locales/layouts.yml
+++ b/config/locales/layouts.yml
@@ -7,3 +7,6 @@ mn:
       coders: Coders
       login: Login
       signup: Register
+      about: About
+      help: Help
+      issues: Issues

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -193,6 +193,7 @@ mn:
     list:
       delete?: "Энэ бодолтыг нээрээ устгах уу?"
       wait-checking: "Please wait or solve other problems, your solution is being checked..."
+      compiler_output: Compiler Output
       <<: *shared-solution
       <<: *results-common
   search:

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -147,6 +147,9 @@ mn:
       <<: *tests-common
     new:
       title: Шинэ тэст
+      add_new_test: Add New Test
+      this_is_hidden_test: This is hidden test
+      save: Save
       <<: *tests-common
     edit:
       title: Тэстийг засварлах

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -74,6 +74,7 @@ mn:
   posts:
     index:
       new_post: New Post
+      edit: Edit
     blog:
       title: Блог
     help:

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -248,6 +248,7 @@ mn:
   user_sessions:
     new:
       title: Нэвтрэх
+      sign_in_using_your_registered_: Please do Login
   twit:
     opening_announcement: >-
       %{name} тэмцээн зарлагдаа.

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -72,6 +72,8 @@ mn:
       taken-points: Оноо
 
   posts:
+    index:
+      new_post: New Post
     blog:
       title: Блог
     help:

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -148,6 +148,7 @@ mn:
     new:
       title: Шинэ тэст
       add_new_test: Add New Test
+      new_test: New Test
       this_is_hidden_test: This is hidden test
       save: Save
       <<: *tests-common

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -211,6 +211,8 @@ mn:
       language: Language
       submit: Submit
       cancel: Cancel
+    list:
+      submitted: Submitted
   user_session:
     new:
       title: Нэвтрэх

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -249,6 +249,7 @@ mn:
     new:
       title: Нэвтрэх
       sign_in_using_your_registered_: Please do Login
+      sign_in: Log In
   twit:
     opening_announcement: >-
       %{name} тэмцээн зарлагдаа.

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -78,6 +78,7 @@ mn:
       posted_on: "Posted On"
     blog:
       title: Блог
+      read_more: Read More
     help:
       title: Тусламж
     show:

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -153,6 +153,7 @@ mn:
   problems:
     index:
       title: "Бодлогууд"
+      problems: Problems
     proposed:
       title: "Дэвшигдсэн бодлогууд"
       limits: "Хязгаарлалт"

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -206,7 +206,7 @@ mn:
       title: Бодолт илгээх
     edit:
       title: '%{subject} · Бодолт засварлах'
-      edit: Edit a Solution   
+      edit_a_solution: Edit a Solution   
       source: Source
       language: Language
       submit: Submit

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -86,6 +86,8 @@ mn:
       posted_on: Posted On
     edit:
       title: "%{subject} · Засварлах"
+      save: Save
+      delete: Delete
   home:
     about:
       title: Сайтын тухай

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -82,6 +82,7 @@ mn:
       title: Тусламж
     show:
       title: "%{subject}"
+      posted_on: Posted On
     edit:
       title: "%{subject} · Засварлах"
   home:

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -213,6 +213,10 @@ mn:
       inform-new-contest: "Шинэ тэмцээн зохиогдоход мэдэгдэх"
     new:
       title: Бүртгүүлэх
+      create_your_account: Create Your Account
+      sign_in_using_social_network: Sign In Using Social Network
+      create_your_free_account: Create Your Free Account
+      register: Register
     edit:
       title: '%{subject} · Тохиргоог шинэчлэх'
       change-password: "Нууц үг солих"

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -190,6 +190,8 @@ mn:
       run-status: Ажилласан байдал
     show:
       title: Тэстийн үр дүн
+      input: Input 
+      output: Output
     list:
       delete?: "Энэ бодолтыг нээрээ устгах уу?"
       wait-checking: "Please wait or solve other problems, your solution is being checked..."

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -75,6 +75,7 @@ mn:
     index:
       new_post: New Post
       edit: Edit
+      posted_on: "Posted On"
     blog:
       title: Блог
     help:

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -100,6 +100,7 @@ mn:
       <<: *shared-problem
     index:
       title: "Тэмцээнүүд"
+      visit_contest: "Visit Contest"
     last:
       title: "Тэмцээн"
     show:

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -120,6 +120,8 @@ mn:
   password_resets:
     new:
       title: Нууц үг сэргээх хүсэлт
+      password_reset: Password Reset
+      enter_your_registered_email: Enter Your Registered Email
     edit:
       title: Нууц үгээ сэргээх
   problem_tests:

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -190,6 +190,13 @@ mn:
       run-status: Ажилласан байдал
     show:
       title: Тэстийн үр дүн
+      coder: Coder
+      souce: Source
+      submitted: Submitted      
+      result: Result
+      program: Program
+      time: Time
+      memory: Memory
       input: Input 
       output: Output
     list:

--- a/config/locales/prudge.yml
+++ b/config/locales/prudge.yml
@@ -206,6 +206,11 @@ mn:
       title: Бодолт илгээх
     edit:
       title: '%{subject} · Бодолт засварлах'
+      edit: Edit a Solution   
+      source: Source
+      language: Language
+      submit: Submit
+      cancel: Cancel
   user_session:
     new:
       title: Нэвтрэх


### PR DESCRIPTION
For now I have added some of the cases that were missed. 
There are also buttons in the top menu. They all were translated in `en.yml` file but with `en:` language. Prudge was looking for `:mn` and didn't find needed strings. That need's to be fixed by changing `en:` to `mn:` en `en.yml` or by any other way. I will create an issue about that now.